### PR TITLE
error if provided python executable doesnt exist

### DIFF
--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -15,11 +15,15 @@ if ($env:COLCON_PYTHON_EXECUTABLE) {
   $_colcon_python_executable="@(python_executable)"
   # if it doesn't exist try a fall back
   if (!(Test-Path "$_colcon_python_executable" -PathType Leaf)) {
-    if (!(Get-Command "python" -ErrorAction SilentlyContinue)) {
-      echo "error: unable to find Python executable"
+@{
+import sys
+python_fallback_executable = 'python' if sys.platform == 'win32' else 'python3'
+}@
+    if (!(Get-Command "@(python_fallback_executable)" -ErrorAction SilentlyContinue)) {
+      echo "error: unable to find @(python_fallback_executable) executable"
       exit 1
     }
-    $_colcon_python_executable="python"
+    $_colcon_python_executable="@(python_fallback_executable)"
   }
 }
 

--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -3,19 +3,24 @@
 # This script extends the environment with all packages contained in this
 # prefix path.
 
-# use the Python executable known at configure time
-$_colcon_python_executable="@(python_executable)"
-# allow overriding it with a custom location
+# check environment variable for custom Python executable
 if ($env:COLCON_PYTHON_EXECUTABLE) {
-  $_colcon_python_executable="$env:COLCON_CURRENT_PREFIX"
-}
-# if the Python executable doesn't exist try another fall back
-if (!(Test-Path "$_colcon_python_executable" -PathType Leaf)) {
-  if (Get-Command "python" -ErrorAction SilentlyContinue) {
-    $_colcon_python_executable="python"
-  } else {
-    echo "error: unable to find fallback Python executable"
+  if (!(Test-Path "$env:COLCON_CURRENT_PREFIX" -PathType Leaf)) {
+    echo "error: COLCON_PYTHON_EXECUTABLE '%COLCON_PYTHON_EXECUTABLE%' doesn't exist"
     return 1
+  }
+  $_colcon_python_executable="$env:COLCON_CURRENT_PREFIX"
+} else {
+  # use the Python executable known at configure time
+  $_colcon_python_executable="@(python_executable)"
+  # if it doesn't exist try a fall back
+  if (!(Test-Path "$_colcon_python_executable" -PathType Leaf)) {
+    if (Get-Command "python" -ErrorAction SilentlyContinue) {
+      $_colcon_python_executable="python"
+    } else {
+      echo "error: unable to find Python executable"
+      return 1
+    }
   }
 }
 

--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -6,7 +6,7 @@
 # check environment variable for custom Python executable
 if ($env:COLCON_PYTHON_EXECUTABLE) {
   if (!(Test-Path "$env:COLCON_PYTHON_EXECUTABLE" -PathType Leaf)) {
-    echo "error: COLCON_PYTHON_EXECUTABLE '%COLCON_PYTHON_EXECUTABLE%' doesn't exist"
+    echo "error: COLCON_PYTHON_EXECUTABLE '$env:COLCON_PYTHON_EXECUTABLE' doesn't exist"
     return 1
   }
   $_colcon_python_executable="$env:COLCON_PYTHON_EXECUTABLE"

--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -5,11 +5,11 @@
 
 # check environment variable for custom Python executable
 if ($env:COLCON_PYTHON_EXECUTABLE) {
-  if (!(Test-Path "$env:COLCON_CURRENT_PREFIX" -PathType Leaf)) {
+  if (!(Test-Path "$env:COLCON_PYTHON_EXECUTABLE" -PathType Leaf)) {
     echo "error: COLCON_PYTHON_EXECUTABLE '%COLCON_PYTHON_EXECUTABLE%' doesn't exist"
     return 1
   }
-  $_colcon_python_executable="$env:COLCON_CURRENT_PREFIX"
+  $_colcon_python_executable="$env:COLCON_PYTHON_EXECUTABLE"
 } else {
   # use the Python executable known at configure time
   $_colcon_python_executable="@(python_executable)"

--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -7,7 +7,7 @@
 if ($env:COLCON_PYTHON_EXECUTABLE) {
   if (!(Test-Path "$env:COLCON_PYTHON_EXECUTABLE" -PathType Leaf)) {
     echo "error: COLCON_PYTHON_EXECUTABLE '$env:COLCON_PYTHON_EXECUTABLE' doesn't exist"
-    return 1
+    exit 1
   }
   $_colcon_python_executable="$env:COLCON_PYTHON_EXECUTABLE"
 } else {
@@ -15,12 +15,11 @@ if ($env:COLCON_PYTHON_EXECUTABLE) {
   $_colcon_python_executable="@(python_executable)"
   # if it doesn't exist try a fall back
   if (!(Test-Path "$_colcon_python_executable" -PathType Leaf)) {
-    if (Get-Command "python" -ErrorAction SilentlyContinue) {
-      $_colcon_python_executable="python"
-    } else {
+    if (!(Get-Command "python" -ErrorAction SilentlyContinue)) {
       echo "error: unable to find Python executable"
-      return 1
+      exit 1
     }
+    $_colcon_python_executable="python"
   }
 }
 


### PR DESCRIPTION
if none provided and compile time not available, fallback to the one on the path.

Similar to https://github.com/colcon/colcon-core/pull/86

Not tested yet