### PR TITLE
_colcon_ordered_commands might be null

### DIFF
--- a/colcon_powershell/shell/template/prefix.ps1.em
+++ b/colcon_powershell/shell/template/prefix.ps1.em
@@ -57,4 +57,6 @@ if ($env:COLCON_TRACE) {
   $_colcon_ordered_commands.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries) | Write-Output
   echo ">>>"
 }
-$_colcon_ordered_commands.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries) | Invoke-Expression
+if ($_colcon_ordered_commands) {
+  $_colcon_ordered_commands.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries) | Invoke-Expression
+}


### PR DESCRIPTION
I really haven't read what `_local_setup_util_ps1.py` is doing, but when sourcing `local_setup.ps1` in some workspaces I get:

> You cannot call a method on a null-valued expression.
> At C:\Users\Administrator\Documents\testing_ivanpauno\tutorials_ws\install\local_setup.ps1:53 char:1
> + $_colcon_ordered_commands.Split([Environment]::NewLine, [StringSplitO ...
> + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
>    + FullyQualifiedErrorId : InvokeMethodOnNull

This PR solves the issue.

---

My guess is that `_local_setup_util_ps1.py` is avoiding to source files that were already source before (or sth like that), and that sometimes end up with a `null` result (?).