### PR TITLE
Implement create_hook_append_value

### DIFF
--- a/colcon_powershell/shell/powershell.py
+++ b/colcon_powershell/shell/powershell.py
@@ -117,6 +117,21 @@ class PowerShellExtension(ShellExtensionPoint):
                     lambda hook: str(hook[0]).endswith('.ps1'), hooks)),
             })
 
+    def create_hook_append_value(  # noqa: D102
+        self, env_hook_name, prefix_path, pkg_name, name, subdirectory,
+    ):
+        hook_path = prefix_path / 'share' / pkg_name / 'hook' / \
+            ('%s.ps1' % env_hook_name)
+        logger.info("Creating environment hook '%s'" % hook_path)
+        expand_template(
+            Path(__file__).parent / 'template' / 'hook_append_value.ps1.em',
+            hook_path,
+            {
+                'name': name,
+                'subdirectory': subdirectory,
+            })
+        return hook_path
+
     def create_hook_prepend_value(  # noqa: D102
         self, env_hook_name, prefix_path, pkg_name, name, subdirectory,
     ):

--- a/colcon_powershell/shell/template/hook_append_value.ps1.em
+++ b/colcon_powershell/shell/template/hook_append_value.ps1.em
@@ -1,0 +1,8 @@
+# generated from colcon_powershell/shell/template/hook_append_value.ps1.em
+
+@{
+value = '$env:COLCON_CURRENT_PREFIX'
+if subdirectory:
+    value += '\\' + subdirectory
+}@
+colcon_append_unique_value @(name) "@(value)"

--- a/colcon_powershell/shell/template/package.ps1.em
+++ b/colcon_powershell/shell/template/package.ps1.em
@@ -1,5 +1,56 @@
 # generated from colcon_powershell/shell/template/package.ps1.em
 
+# function to append a value to a variable
+# which uses colons as separators
+# duplicates as well as leading separators are avoided
+# first argument: the name of the result variable
+# second argument: the value to be prepended
+function colcon_append_unique_value {
+  param (
+    $_listname,
+    $_value
+  )
+
+  # get values from variable
+  if (Test-Path Env:$_listname) {
+    $_values=(Get-Item env:$_listname).Value
+  } else {
+    $_values=""
+  }
+  $_duplicate=""
+  # start with no values
+  $_all_values=""
+  # iterate over existing values in the variable
+  if ($_values) {
+    $_values.Split(";") | ForEach {
+      # not an empty string
+      if ($_) {
+        # not a duplicate of _value
+        if ($_ -eq $_value) {
+          $_duplicate="1"
+        }
+        if ($_all_values) {
+          $_all_values="${_all_values};$_"
+        } else {
+          $_all_values="$_"
+        }
+      }
+    }
+  }
+  # append only non-duplicates
+  if (!$_duplicate) {
+    # avoid leading separator
+    if ($_all_values) {
+      $_all_values="${_all_values};${_value}"
+    } else {
+      $_all_values="${_value}"
+    }
+  }
+
+  # export the updated variable
+  Set-Item env:\$_listname -Value "$_all_values"
+}
+
 # function to prepend a value to a variable
 # which uses colons as separators
 # duplicates as well as trailing separators are avoided


### PR DESCRIPTION
Support for this part of the ShellExtensionPoint class was templated, but no shells implemented it.

Connects to colcon/colcon-core#426, but can be merged independently.