### PR TITLE
Improve speed by using -NoProfile flag

### DIFF
--- a/colcon_powershell/shell/powershell.py
+++ b/colcon_powershell/shell/powershell.py
@@ -178,7 +178,7 @@ class PowerShellExtension(ShellExtensionPoint):
             raise RuntimeError(
                 "Could not find '{powershell_executable_name}' executable"
                 .format(powershell_executable_name=powershell_executable_name))
-        cmd = [POWERSHELL_EXECUTABLE, '-Command', ' '.join(cmd)]
+        cmd = [POWERSHELL_EXECUTABLE, '-NoProfile', '-Command', ' '.join(cmd)]
         env = await get_environment_variables(
             cmd, cwd=str(build_base), shell=False)
 


### PR DESCRIPTION
Using the `-NoProfile` flag [disables loading the PowerShell profile](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-noprofile).

By default, most users do not have a PowerShell Profile, so this will not affect performance or functionality for them. However, using a Powershell profile will allow you to run some commands on startup (such as sourcing ROS or setting up a Visual Studio Developer PowerShell). These commands can take a couple seconds, which can easily add up since this will be rerun for every package. 

The slow profiles don't need to be run when building packages, so it can improve speed for users who have heavy profiles.