### PR TITLE
Use platform-native separators in environment variables

### DIFF
--- a/colcon_powershell/shell/template/hook_append_value.ps1.em
+++ b/colcon_powershell/shell/template/hook_append_value.ps1.em
@@ -1,8 +1,9 @@
 # generated from colcon_powershell/shell/template/hook_append_value.ps1.em
 
 @{
+import os
 value = '$env:COLCON_CURRENT_PREFIX'
 if subdirectory:
-    value += '\\' + subdirectory
+    value += os.sep + subdirectory
 }@
 colcon_append_unique_value @(name) "@(value)"

--- a/colcon_powershell/shell/template/hook_prepend_value.ps1.em
+++ b/colcon_powershell/shell/template/hook_prepend_value.ps1.em
@@ -1,8 +1,9 @@
 # generated from colcon_powershell/shell/template/hook_prepend_value.ps1.em
 
 @{
+import os
 value = '$env:COLCON_CURRENT_PREFIX'
 if subdirectory:
-    value += '\\' + subdirectory
+    value += os.sep + subdirectory
 }@
 colcon_prepend_unique_value @(name) "@(value)"

--- a/colcon_powershell/shell/template/package.ps1.em
+++ b/colcon_powershell/shell/template/package.ps1.em
@@ -1,3 +1,4 @@
+@{import os}@
 # generated from colcon_powershell/shell/template/package.ps1.em
 
 # function to append a value to a variable
@@ -22,7 +23,7 @@ function colcon_append_unique_value {
   $_all_values=""
   # iterate over existing values in the variable
   if ($_values) {
-    $_values.Split(";") | ForEach {
+    $_values.Split("@(os.pathsep)") | ForEach {
       # not an empty string
       if ($_) {
         # not a duplicate of _value
@@ -30,7 +31,7 @@ function colcon_append_unique_value {
           $_duplicate="1"
         }
         if ($_all_values) {
-          $_all_values="${_all_values};$_"
+          $_all_values="${_all_values}@(os.pathsep)$_"
         } else {
           $_all_values="$_"
         }
@@ -41,7 +42,7 @@ function colcon_append_unique_value {
   if (!$_duplicate) {
     # avoid leading separator
     if ($_all_values) {
-      $_all_values="${_all_values};${_value}"
+      $_all_values="${_all_values}@(os.pathsep)${_value}"
     } else {
       $_all_values="${_value}"
     }
@@ -72,13 +73,13 @@ function colcon_prepend_unique_value {
   $_all_values="$_value"
   # iterate over existing values in the variable
   if ($_values) {
-    $_values.Split(";") | ForEach {
+    $_values.Split("@(os.pathsep)") | ForEach {
       # not an empty string
       if ($_) {
         # not a duplicate of _value
         if ($_ -ne $_value) {
           # keep non-duplicate values
-          $_all_values="${_all_values};$_"
+          $_all_values="${_all_values}@(os.pathsep)$_"
         }
       }
     }
@@ -113,7 +114,7 @@ function colcon_package_source_powershell_script {
 $env:COLCON_CURRENT_PREFIX=(Get-Item $PSCommandPath).Directory.Parent.Parent.FullName
 
 @[end if]@
-colcon_package_source_powershell_script "$env:COLCON_CURRENT_PREFIX\@(hook[0])"@
+colcon_package_source_powershell_script "$env:COLCON_CURRENT_PREFIX@(os.sep)@(hook[0])"@
 @[  for hook_arg in hook[1]]@
  @(hook_arg)@
 @[  end for]

--- a/colcon_powershell/shell/template/prefix_chain.ps1.em
+++ b/colcon_powershell/shell/template/prefix_chain.ps1.em
@@ -1,3 +1,4 @@
+@{import os}
 # generated from colcon_powershell/shell/template/prefix_chain.ps1.em
 
 # This script extends the environment with the environment of other prefix
@@ -24,10 +25,10 @@ function _colcon_prefix_chain_powershell_source_script {
 
 # source chained prefixes
 @[  for prefix in reversed(chained_prefix_path)]@
-_colcon_prefix_chain_powershell_source_script "@(prefix)\@(prefix_script_no_ext).ps1"
+_colcon_prefix_chain_powershell_source_script "@(prefix)@(os.sep)@(prefix_script_no_ext).ps1"
 @[  end for]@
 @[end if]@
 
 # source this prefix
 $env:COLCON_CURRENT_PREFIX=(Split-Path $PSCommandPath -Parent)
-_colcon_prefix_chain_powershell_source_script "$env:COLCON_CURRENT_PREFIX\@(prefix_script_no_ext).ps1"
+_colcon_prefix_chain_powershell_source_script "$env:COLCON_CURRENT_PREFIX@(os.sep)@(prefix_script_no_ext).ps1"


### PR DESCRIPTION
PowerShell can be used on non-Windows platforms. It appears that when PowerShell is used on Linux, the platform-native separators (forward slash and colon) are used, and not the Windows-style separators (backslash and semicolon).

Closes #39