### PR TITLE
Never select PowerShell if it isn't available

### DIFF
--- a/colcon_powershell/shell/powershell.py
+++ b/colcon_powershell/shell/powershell.py
@@ -68,6 +68,9 @@ class PowerShellExtension(ShellExtensionPoint):
         else:
             self._is_primary = bool(os.environ.get('PSModulePath'))
 
+        if not POWERSHELL_EXECUTABLE:
+            self._is_primary = False
+
     def get_file_extensions(self):  # noqa: D102
         return ('ps1', )
 


### PR DESCRIPTION
Regardless of our heuristics for determining if PowerShell is in use, we should never attempt to use PowerShell as the primary shell if it isn't installed.