### PR TITLE
Use null-separated output for PowerShell environments

### DIFF
--- a/colcon_powershell/shell/powershell.py
+++ b/colcon_powershell/shell/powershell.py
@@ -11,7 +11,7 @@ from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_core.prefix_path import get_chained_prefix_path
 from colcon_core.shell import check_dependency_availability
-from colcon_core.shell import get_environment_variables
+from colcon_core.shell import get_null_separated_environment_variables
 from colcon_core.shell import logger
 from colcon_core.shell import ShellExtensionPoint
 from colcon_core.shell.template import expand_template
@@ -181,14 +181,14 @@ class PowerShellExtension(ShellExtensionPoint):
             '(Get-Item Env:).GetEnumerator()',
             '|',
             'ForEach-Object',
-            '{ "$($_.Key)=$($_.Value)" }'
+            '{ [Console]::Write("$($_.Key)=$($_.Value)`0") }'
         ]
         if POWERSHELL_EXECUTABLE is None:
             raise RuntimeError(
                 "Could not find '{powershell_executable_name}' executable"
                 .format(powershell_executable_name=powershell_executable_name))
         cmd = [POWERSHELL_EXECUTABLE, '-NoProfile', '-Command', ' '.join(cmd)]
-        env = await get_environment_variables(
+        env = await get_null_separated_environment_variables(
             cmd, cwd=str(build_base), shell=False)
 
         # write environment variables to file for debugging

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 [options]
 python_requires = >=3.6
 install_requires =
-  colcon-core>=0.12.0
+  colcon-core>=0.19.0
 packages = find:
 zip_safe = false
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-powershell]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.12.0)
+Depends3: python3-colcon-core (>= 0.19.0)
 Suite: focal jammy noble resolute bookworm trixie
 X-Python3-Version: >= 3.6
 Upstream-Version-Suffix: +upstream

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,7 +1,10 @@
 apache
+asyncio
 colcon
+distro
 iterdir
 linter
+monkeypatch
 noqa
 pathext
 pathexts
@@ -12,6 +15,7 @@ prepend
 pwsh
 pydocstyle
 pytest
+pythonpath
 rtype
 scspell
 setuptools

--- a/test/test_powershell.py
+++ b/test/test_powershell.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The colcon-powershell contributors
+# Licensed under the Apache License, Version 2.0
+
+import asyncio
+
+import colcon_core.shell
+from colcon_powershell.shell import powershell
+
+
+def test_command_environment_preserves_names_and_values(monkeypatch, tmp_path):
+    async def check_output(cmd, **kwargs):
+        delimiter = b'\0' if '`0' in cmd[-1] else b'\n'
+        return delimiter.join([
+            b'PYTHONPATH=/opt/ros/jazzy/lib/python3.12/site-packages',
+            b'INPUT_TARGET-ROS1-DISTRO=',
+            b'MULTILINE=first\nsecond',
+        ]) + delimiter
+
+    monkeypatch.setattr(colcon_core.shell, 'check_output', check_output)
+    monkeypatch.setattr(powershell, 'POWERSHELL_EXECUTABLE', 'pwsh')
+
+    extension = powershell.PowerShellExtension()
+    extension._is_primary = True
+    loop = asyncio.new_event_loop()
+    try:
+        env = loop.run_until_complete(extension.generate_command_environment(
+            'test', tmp_path, {}))
+    finally:
+        loop.close()
+
+    assert env['PYTHONPATH'] == \
+        '/opt/ros/jazzy/lib/python3.12/site-packages'
+    assert env['INPUT_TARGET-ROS1-DISTRO'] == ''
+    assert env['MULTILINE'] == 'first\nsecond'


### PR DESCRIPTION
PowerShell currently prints environment variables one per line before passing them back to colcon. This becomes ambiguous when a value contains a newline.

It also causes problems on Linux when an environment variable name contains a hyphen. For example, `INPUT_TARGET-ROS1-DISTRO` can be treated as a continuation of the preceding `PYTHONPATH` value, which then causes unrelated Python imports to fail.

This change writes each `name=value` entry with a null terminator and uses colcon-core's null-separated environment parser. The minimum colcon-core version is raised to 0.19.0, where that parser was introduced.

A regression test covers both hyphenated variable names and multiline values.

Tested with:

- `pytest -q` — 6 passed
- PowerShell 7.4.2 on Linux